### PR TITLE
Allows local development on HTTPS 

### DIFF
--- a/js/mediaQueryBookmarklet.js
+++ b/js/mediaQueryBookmarklet.js
@@ -212,7 +212,7 @@ window.mqb = {
     mqb.css.type = "text/css";
     mqb.css.rel = "stylesheet";
     mqb.css.href = "http://sparkbox.github.com/mediaQueryBookmarklet/stylesheets/mediaQuery.css";
-    mqb.css.href = "http://localhost/mediaQueryBookmarklet/css/mediaQuery.css";
+    mqb.css.href = "/mediaQueryBookmarklet/css/mediaQuery.css";
     document.head.appendChild( mqb.css );
   },
 


### PR DESCRIPTION
I removed the `http://localhost` portion from the `loadCSS` function in the non-bookmarklet  file so that I could use this on my local machine for developing HTTPS sites as Github doesn't provide HTTPS access to Pages.
