### PR TITLE
fix: make bookmarklet load JS from HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
           <p class="description">The mediaQuery bookmarklet gives a visual representation of the current viewport dimensions and most recently fired media query.</p>
           <ul class="getItList">
             <li class="getItList-item">
-              <a class="button button-gray" href="javascript:%20(function%20()%20{var%20jsCode%20=%20document.createElement(%27script%27);jsCode.setAttribute(%27src%27,%20%27http://sparkbox.github.com/mediaQueryBookmarklet/bookmarklet-js/mediaQueryBookmarklet.js%27);document.body.appendChild(jsCode);}());">
+              <a class="button button-gray" href="javascript:%20(function%20()%20{var%20jsCode%20=%20document.createElement(%27script%27);jsCode.setAttribute(%27src%27,%20%27https://sparkbox.github.io/mediaQueryBookmarklet/bookmarklet-js/mediaQueryBookmarklet.js%27);document.body.appendChild(jsCode);}());">
                 mediaQuery Bookmarklet
               </a>
               <p><small>Drag to browser toolbar</small></p>


### PR DESCRIPTION
I was still seeing security errors after the CSS reference update. I think this should do it.